### PR TITLE
fix non-json logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.56.0
+    hooks:
+      - id: golangci-lint

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -103,9 +103,11 @@ func configFileNotFound(err error) bool {
 }
 
 func initLogs() {
-	// Unfortunately, we cannot log in this function or it breaks plugins by sending non-plugin api messages across the pipe
-	// The default formatter is JSON
-	if !flags.GetBool(rootCmd, "log-json") {
+	// Unfortunately, we cannot log in this function, or it breaks plugins by sending non-plugin api messages across the pipe
+
+	if flags.GetBool(rootCmd, "log-json") {
+		log.SetFormatter(&log.JSONFormatter{TimestampFormat: time.RFC3339})
+	} else {
 		log.SetFormatter(&prefixed.TextFormatter{
 			FullTimestamp:   true,
 			TimestampFormat: time.Stamp,


### PR DESCRIPTION
the json format wasn't always set with `--log-json`, also plugins could start logging before the formatter and log level were configured