### PR TITLE
Allow getVersions to contain versions from current iscenv instance images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,13 @@ require (
 	golang.org/x/term v0.32.0
 )
 
+// Use porter's fork which silences yamux output
+// See:
+//   https://github.com/hashicorp/go-plugin/issues/169
+//   https://github.com/hashicorp/go-plugin/issues/205
+//   https://github.com/hashicorp/go-plugin/issues/248
+replace github.com/hashicorp/go-plugin => github.com/getporter/go-plugin v1.4.4-porter.1
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -40,6 +47,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.1.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
@@ -65,7 +73,7 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9 // indirect
-	google.golang.org/grpc v1.72.0 // indirect
+	google.golang.org/grpc v1.72.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
-github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -36,6 +34,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fsouza/go-dockerclient v1.12.1 h1:FMoLq+Zhv9Oz/rFmu6JWkImfr6CBgZOPcL+bHW4gS0o=
 github.com/fsouza/go-dockerclient v1.12.1/go.mod h1:OqsgJJcpCwqyM3JED7TdfM9QVWS5O7jSYwXxYKmOooY=
+github.com/getporter/go-plugin v1.4.4-porter.1 h1:Ot8WNy6/2irfaRJhyF+ySXmmNfg5OPn2KzeN4OWTRDg=
+github.com/getporter/go-plugin v1.4.4-porter.1/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -73,8 +73,6 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0UUrwg=
-github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
@@ -82,8 +80,8 @@ github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
-github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
+github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
+github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -108,6 +106,8 @@ github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 h1:YocNLcTBdEd
 github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2/go.mod h1:76rfSfYPWj01Z85hUf/ituArm797mNKcvINh1OlsZKo=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
+github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.1.0 h1:Kk/5rdW/g+H8NHdJW2gsXyZ7UnzvJNOy6VKJqueWdcQ=
@@ -254,8 +254,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9 h1:IkAfh6J/yllPtpYFU0zZN1hUPYdT0ogkBT/9hMxHjvg=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
-google.golang.org/grpc v1.72.0 h1:S7UkcVa60b5AAQTaO6ZKamFp1zMZSU0fGDK2WZLbBnM=
-google.golang.org/grpc v1.72.0/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
+google.golang.org/grpc v1.72.1 h1:HR03wO6eyZ7lknl75XlxABNVLLFc2PAb6mHlYh756mA=
+google.golang.org/grpc v1.72.1/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/internal/app/getinstancesversions.go
+++ b/internal/app/getinstancesversions.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ontariosystems/iscenv/v3/iscenv"
+)
+
+// GetInstancesVersions returns list of ISCVersions matching an image for all current ISCInstances
+func GetInstancesVersions(image string) (versions iscenv.ISCVersions, err error) {
+	instances := GetInstances()
+	versions = make(iscenv.ISCVersions, 0, len(instances))
+	for _, i := range instances {
+		if i.Image == image {
+			ai, err := DockerClient.InspectImage(fmt.Sprintf("%s:%s", i.Image, i.Version))
+			if err != nil {
+				return nil, err
+			}
+
+			versions.AddIfMissing(&iscenv.ISCVersion{
+				ID:      strings.TrimPrefix(ai.ID, "sha256:"),
+				Version: i.Version,
+				Created: ai.Created.Unix(),
+				Source:  "instances",
+			})
+		}
+	}
+	return
+}

--- a/internal/cmd/addlifecyclerflags.go
+++ b/internal/cmd/addlifecyclerflags.go
@@ -35,7 +35,7 @@ func addLifecyclerFlagsIfNeeded(cmd *cobra.Command) error {
 func addLifecyclerFlags(cmd *cobra.Command) error {
 	// Logging can't have been configured yet, so we're using an empty PluginArgs
 	var lcs []*plugins.ActivatedLifecycler
-	defer getActivatedLifecyclers(nil, plugins.PluginArgs{}, &lcs)()
+	defer getActivatedLifecyclers(nil, plugins.PluginArgs{}, &lcs)(rootCtx)
 
 	available := make([]string, len(lcs))
 	for i, lc := range lcs {

--- a/internal/cmd/getactivatedlifecyclers.go
+++ b/internal/cmd/getactivatedlifecyclers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+
 	"github.com/ontariosystems/iscenv/v3/internal/app"
 	"github.com/ontariosystems/iscenv/v3/internal/plugins"
 	log "github.com/sirupsen/logrus"
@@ -24,14 +26,14 @@ import (
 
 // getActivatedLifecyclers will populate lifecyclers with activated lifecyclers plugins based on the provided list.
 // It returns the close function from the manager so you can easily defer the return.  It will log fatally on any errors
-func getActivatedLifecyclers(pluginsToActivate []string, args plugins.PluginArgs, lifecyclers *[]*plugins.ActivatedLifecycler) func() {
+func getActivatedLifecyclers(pluginsToActivate []string, args plugins.PluginArgs, lifecyclers *[]*plugins.ActivatedLifecycler) func(ctx context.Context) {
 	var err error
 	lcm, err := plugins.NewLifecyclerManager(args)
 	if err != nil {
 		logAndExit(app.ErrorLogger(log.StandardLogger(), err), "Failed to create lifecycle plugin manager")
 	}
 
-	*lifecyclers, err = lcm.ActivatePlugins(pluginsToActivate)
+	*lifecyclers, err = lcm.ActivatePlugins(rootCtx, pluginsToActivate)
 	if err != nil {
 		logAndExit(app.ErrorLogger(log.StandardLogger(), err), "Failed to activate lifecycle plugins")
 	}

--- a/internal/cmd/getactivatedversioners.go
+++ b/internal/cmd/getactivatedversioners.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+
 	"github.com/ontariosystems/iscenv/v3/internal/app"
 	"github.com/ontariosystems/iscenv/v3/internal/plugins"
 	log "github.com/sirupsen/logrus"
@@ -24,14 +26,14 @@ import (
 
 // getActivatedVersioners will populate versioners with activated versioners plugins based on the provided list.
 // It returns the close function from the manager so you can easily defer the return.  It will log fatally on any errors
-func getActivatedVersioners(pluginsToActivate []string, args plugins.PluginArgs, versioners *[]*plugins.ActivatedVersioner) func() {
+func getActivatedVersioners(pluginsToActivate []string, args plugins.PluginArgs, versioners *[]*plugins.ActivatedVersioner) func(ctx context.Context) {
 	var err error
 	vm, err := plugins.NewVersionerManager(getPluginArgs())
 	if err != nil {
 		logAndExit(app.ErrorLogger(log.StandardLogger(), err), "Failed to create version plugin manager")
 	}
 
-	*versioners, err = vm.ActivatePlugins(pluginsToActivate)
+	*versioners, err = vm.ActivatePlugins(rootCtx, pluginsToActivate)
 	if err != nil {
 		logAndExit(app.ErrorLogger(log.StandardLogger(), err), "Failed to activate version plugins")
 	}

--- a/internal/cmd/internalstart.go
+++ b/internal/cmd/internalstart.go
@@ -91,7 +91,7 @@ func internalStart(cmd *cobra.Command, _ []string) {
 	startStatus.Update(app.StartPhaseInitPlugins, nil, "")
 
 	var lcs []*plugins.ActivatedLifecycler
-	defer getActivatedLifecyclers(pluginsToActivate, getPluginArgs(), &lcs)()
+	defer getActivatedLifecyclers(pluginsToActivate, getPluginArgs(), &lcs)(rootCtx)
 	for _, lc := range lcs {
 		startStatus.Update(app.StartPhaseInitPlugins, nil, lc.Id)
 	}

--- a/internal/cmd/rm.go
+++ b/internal/cmd/rm.go
@@ -36,7 +36,7 @@ func init() {
 
 func rm(cmd *cobra.Command, args []string) {
 	var lcs []*plugins.ActivatedLifecycler
-	defer getActivatedLifecyclers(getPluginsToActivate(rootCmd), getPluginArgs(), &lcs)()
+	defer getActivatedLifecyclers(getPluginsToActivate(rootCmd), getPluginArgs(), &lcs)(rootCtx)
 
 	instances := getMultipleInstances(cmd, args)
 	for _, instanceName := range instances {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -45,9 +46,11 @@ var rootCmd = &cobra.Command{
 	Version: iscenv.Version,
 }
 
+var rootCtx = context.Background()
+
 // Execute runs the root functionality of the iscenv command
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := rootCmd.ExecuteContext(rootCtx); err != nil {
 		logAndExit(log.WithError(err), "Failed to execute iscenv command")
 	}
 }
@@ -67,11 +70,11 @@ func init() {
 	// This flag is the image which will be used by default when creating new containers or listing versions.
 	flags.AddFlagComplex(rootCmd, true, true, "image", "", "", "the image to use when creating ISC product containers.  You will want to set a default for this in your configuration file (eg. mycompany/ensemble)")
 
-	// This allows us to set lifecycle plugins across the multiple commands to which they belong will still allowing versioners to use their own set of plugins
+	// This allows us to set lifecycle plugins across the multiple commands to which they belong, while still allowing versioners to use their own set of plugins
 	if !skipPluginActivation() {
 		// Logging can't have been configured yet, so we're using an empty PluginArgs
 		var lcs []*plugins.ActivatedLifecycler
-		defer getActivatedLifecyclers(nil, plugins.PluginArgs{}, &lcs)()
+		defer getActivatedLifecyclers(nil, plugins.PluginArgs{}, &lcs)(rootCtx)
 		available := make([]string, len(lcs))
 		for i, lc := range lcs {
 			available[i] = lc.Id

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -49,6 +49,7 @@ var (
 
 func init() {
 	rootCmd.AddCommand(startCmd)
+
 	if err := addLifecyclerFlagsIfNeeded(startCmd); err != nil {
 		logAndExit(app.ErrorLogger(log.StandardLogger(), err), app.ErrFailedToAddPluginFlags.Error())
 	}
@@ -82,7 +83,7 @@ func start(cmd *cobra.Command, args []string) {
 	version := getVersion(image, flags.GetString(cmd, "version"))
 
 	var lcs []*plugins.ActivatedLifecycler
-	defer getActivatedLifecyclers(getPluginsToActivate(rootCmd), getPluginArgs(), &lcs)()
+	defer getActivatedLifecyclers(getPluginsToActivate(rootCmd), getPluginArgs(), &lcs)(rootCtx)
 
 	environment, copies, volumes, ports, labels, err := getPluginConfig(lcs, cmd, version)
 	if err != nil {

--- a/internal/cmd/stop.go
+++ b/internal/cmd/stop.go
@@ -38,7 +38,7 @@ func init() {
 
 func stop(cmd *cobra.Command, args []string) {
 	var lcs []*plugins.ActivatedLifecycler
-	defer getActivatedLifecyclers(getPluginsToActivate(rootCmd), getPluginArgs(), &lcs)()
+	defer getActivatedLifecyclers(getPluginsToActivate(rootCmd), getPluginArgs(), &lcs)(rootCtx)
 
 	instances := getMultipleInstances(cmd, args)
 	for _, instanceName := range instances {

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -135,10 +135,16 @@ func getVersions(image string, verPlugins []string) (iscenv.ISCVersions, error) 
 
 		plog.WithField("count", len(plugVers)).Debug("Retrieved versions")
 		// TODO: Once some more plugins are implemented this will need to be changed to show what is local, what is remote, what is both but stale, etc.
-		for _, version := range plugVers {
-			versions.AddIfMissing(version)
-		}
+		versions.AddIfMissing(plugVers...)
 	}
+
+	// add any versions from current instances
+	instVers, err := app.GetInstancesVersions(image)
+	if err != nil {
+		return nil, err
+	}
+	versions.AddIfMissing(instVers...)
+
 	versions.Sort()
 	return versions, nil
 }

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -48,7 +48,7 @@ func init() {
 	if err != nil {
 		logAndExit(log.WithError(err), "Failed to load version plugin manager during init")
 	}
-	defer vm.Close()
+	defer vm.Close(rootCtx)
 
 	rootCmd.AddCommand(versionsCmd)
 
@@ -93,7 +93,7 @@ func versions(cmd *cobra.Command, _ []string) {
 	w.Flush()
 }
 
-// Acquire all of the versions for the provided image using the appropriate plugin stack
+// Acquire all the versions for the provided image using the appropriate plugin stack
 func getVersions(image string, verPlugins []string) (iscenv.ISCVersions, error) {
 	// Get the baseline set of versions that are considered "local"
 	var versions iscenv.ISCVersions
@@ -101,7 +101,7 @@ func getVersions(image string, verPlugins []string) (iscenv.ISCVersions, error) 
 	var err error
 
 	log.WithField("plugin", baseVersionPlugin).Debug("Executing default version plugin")
-	defer getActivatedVersioners([]string{baseVersionPlugin}, getPluginArgs(), &versioners)()
+	defer getActivatedVersioners([]string{baseVersionPlugin}, getPluginArgs(), &versioners)(rootCtx)
 	if len(versioners) != 1 {
 		logAndExit(log.WithField("plugin", baseVersionPlugin), "Got more than 1 plugin entry for base version plugin, this should be impossible")
 	}
@@ -116,7 +116,7 @@ func getVersions(image string, verPlugins []string) (iscenv.ISCVersions, error) 
 	plog.WithField("count", len(versions)).Debug("Retrieved versions")
 
 	log.WithField("count", len(verPlugins)).Debug("Executing additional version plugin(s)")
-	defer getActivatedVersioners(verPlugins, getPluginArgs(), &versioners)()
+	defer getActivatedVersioners(verPlugins, getPluginArgs(), &versioners)(rootCtx)
 
 	for _, v := range versioners {
 		// Local was added to the plugins list which makes no sense but isn't worthy of an error (and we don't want to log because it will corrupt the table output of versions)

--- a/internal/plugins/lifecyclermanager.go
+++ b/internal/plugins/lifecyclermanager.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package plugins
 
-import "github.com/ontariosystems/iscenv/v3/iscenv"
+import (
+	"context"
+	"github.com/ontariosystems/iscenv/v3/iscenv"
+)
 
 // NewLifecyclerManager creates and returns a PluginManager for a LifecyclerPlugin
 func NewLifecyclerManager(args PluginArgs) (*LifecyclerManager, error) {
@@ -40,8 +43,8 @@ type ActivatedLifecycler struct {
 }
 
 // ActivatePlugins will activate the provided list of lifecycler plugins.
-func (lm *LifecyclerManager) ActivatePlugins(pluginsToActivate []string) ([]*ActivatedLifecycler, error) {
-	plugins, err := lm.PluginManager.ActivatePlugins(pluginsToActivate)
+func (lm *LifecyclerManager) ActivatePlugins(ctx context.Context, pluginsToActivate []string) ([]*ActivatedLifecycler, error) {
+	plugins, err := lm.PluginManager.ActivatePlugins(ctx, pluginsToActivate)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/pluginmanager.go
+++ b/internal/plugins/pluginmanager.go
@@ -137,8 +137,8 @@ func (pm *PluginManager) AvailablePlugins() []string {
 	return plugins
 }
 
-// ActivatePlugins will activate the provided list of plugins.  If the list is nil, it will activate all of the plugins.
-// It does this by traversing all of the plugins dispensing them to the rpc client and then returning an object containing the Id of the plugin, the path to the executable (if not internal) and the raw plugin interface{} which the caller will likely want to typecast into something more useful.
+// ActivatePlugins will activate the provided list of plugins.  If the list is nil, it will activate all the plugins.
+// It does this by traversing all the plugins dispensing them to the rpc client and then returning an object containing the id of the plugin, the path to the executable (if not internal) and the raw plugin interface{} which the caller will likely want to typecast into something more useful.
 // It will return the ActivatedPlugins in the same order as the pluginsToActivate and any error encountered
 func (pm *PluginManager) ActivatePlugins(ctx context.Context, pluginsToActivate []string) ([]*ActivatedPlugin, error) {
 	if pluginsToActivate == nil {
@@ -151,7 +151,7 @@ func (pm *PluginManager) ActivatePlugins(ctx context.Context, pluginsToActivate 
 
 		client, ok := pm.clients[key]
 		if !ok {
-			return nil, fmt.Errorf("No such plugin, name: %s", key)
+			return nil, fmt.Errorf("no such plugin, name: %s", key)
 		}
 
 		rpcClient, err := client.RPCClient(ctx)

--- a/internal/plugins/versionermanager.go
+++ b/internal/plugins/versionermanager.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package plugins
 
-import "github.com/ontariosystems/iscenv/v3/iscenv"
+import (
+	"context"
+	"github.com/ontariosystems/iscenv/v3/iscenv"
+)
 
 // NewVersionerManager creates and returns a PluginManager for a VersionerPlugin
 func NewVersionerManager(args PluginArgs) (*VersionerManager, error) {
@@ -40,8 +43,8 @@ type ActivatedVersioner struct {
 }
 
 // ActivatePlugins will activate the provided list of versioner plugins.
-func (lm *VersionerManager) ActivatePlugins(pluginsToActivate []string) ([]*ActivatedVersioner, error) {
-	plugins, err := lm.PluginManager.ActivatePlugins(pluginsToActivate)
+func (lm *VersionerManager) ActivatePlugins(ctx context.Context, pluginsToActivate []string) ([]*ActivatedVersioner, error) {
+	plugins, err := lm.PluginManager.ActivatePlugins(ctx, pluginsToActivate)
 	if err != nil {
 		return nil, err
 	}

--- a/iscenv/iscinstance.go
+++ b/iscenv/iscinstance.go
@@ -25,6 +25,7 @@ type ISCInstance struct {
 	ID      string
 	Name    string
 	Version string
+	Image   string
 	Created int64
 	Status  string
 	Ports   ContainerPorts

--- a/iscenv/iscversions.go
+++ b/iscenv/iscversions.go
@@ -41,14 +41,16 @@ func (evs ISCVersions) Less(i, j int) bool {
 	return cmp < 0
 }
 
-// AddIfMissing adds a version to the list if it isn't already included
-func (evs *ISCVersions) AddIfMissing(ev *ISCVersion) bool {
-	if !evs.Exists(ev.Version) {
-		*evs = append(*evs, ev)
-		return true
+// AddIfMissing adds versions to the list if it isn't already included
+func (evs *ISCVersions) AddIfMissing(versions ...*ISCVersion) (added bool) {
+	for _, ev := range versions {
+		if !evs.Exists(ev.Version) {
+			*evs = append(*evs, ev)
+			added = true
+		}
 	}
 
-	return false
+	return
 }
 
 // Latest finds and returns the last version in the list


### PR DESCRIPTION
## The Problem

1. start an instance with a version that is a tag that doesn't match the normal `/^\d+(\.\d+)?$/` pattern. For example:

    ```sh
    iscenv start --version latest iris
    ```

2. stop the instance

    ```sh
    iscenv stop iris
    ```

3. start the existing instance again, but do not specify a version

    ```sh
    iscenv start iris
    ```

This will create the error:
```
ERROR No local versions from which to choose latest, must provide version with --version flag
```
from here: https://github.com/ontariosystems/iscenv/blob/v3.16.6/internal/cmd/start.go#L293

## The Solution
This PR fixes that by including in the list of versions the image tags used by any current iscenv container running from the same image repo.

## Extra stuff
I based this on a branch that also had the following:

- switch go-plugin from hashicorp to fork from [getporter/go-plugin](https://github.com/getporter/go-plugin) to avoid noise from yamux
- add a `--pull` flag to `iscenv start` to allow forcing images to pull on start. This is useful for tags like `latest`

I can make additional PRs for these if it's too confusing.